### PR TITLE
implement metrics-aggregator parent chart, defined values

### DIFF
--- a/charts/metrics-aggregator/.helmignore
+++ b/charts/metrics-aggregator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/metrics-aggregator/Chart.lock
+++ b/charts/metrics-aggregator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: datadog
+  repository: https://helm.datadoghq.com
+  version: 3.0.4
+digest: sha256:52b59841ab313aea69b56fc60809855ac1c98d139597c92356970f013488a7b6
+generated: "2025-01-14T14:55:02.536776-07:00"

--- a/charts/metrics-aggregator/Chart.lock
+++ b/charts/metrics-aggregator/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: datadog
   repository: https://helm.datadoghq.com
   version: 3.0.4
-digest: sha256:52b59841ab313aea69b56fc60809855ac1c98d139597c92356970f013488a7b6
-generated: "2025-01-14T14:55:02.536776-07:00"
+- name: prometheus
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 26.1.0
+digest: sha256:d9a35de533f1ec8f91cc1975c61ab9b1b9f019e8c6c8a0aeb6141216729026ee
+generated: "2025-01-15T15:49:42.481171-07:00"

--- a/charts/metrics-aggregator/Chart.yaml
+++ b/charts/metrics-aggregator/Chart.yaml
@@ -1,0 +1,38 @@
+apiVersion: v2
+name: metrics-aggregator
+description: A Helm chart for metrics-aggregator
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+dependencies:
+  # chart can be found in official repo: https://github.com/DataDog/helm-charts/tree/main/charts/datadog
+  # installation instructions from official docs: https://docs.datadoghq.com/containers/kubernetes/installation/?tab=helm
+  - name: datadog
+    version: ~3.0.0
+    repository: https://helm.datadoghq.com
+  # install prometheus from helm repo: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
+  #- name: prometheus
+  #  version: ~18.0.0
+  #  repository: https://prometheus-community.github.io/helm-charts
+  # install river-metrics-discovery service from subchart defined in ./charts/river-metrics-discovery
+  #- name: river-metrics-discovery
+  #  version: ~0.1.0
+  #  repository: file://../river-metrics-discovery
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/metrics-aggregator/Chart.yaml
+++ b/charts/metrics-aggregator/Chart.yaml
@@ -18,9 +18,9 @@ dependencies:
     version: ~3.0.0
     repository: https://helm.datadoghq.com
   # install prometheus from helm repo: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
-  #- name: prometheus
-  #  version: ~18.0.0
-  #  repository: https://prometheus-community.github.io/helm-charts
+  - name: prometheus
+    version: ~26.1.0
+    repository: https://prometheus-community.github.io/helm-charts
   # install river-metrics-discovery service from subchart defined in ./charts/river-metrics-discovery
   #- name: river-metrics-discovery
   #  version: ~0.1.0

--- a/charts/metrics-aggregator/templates/NOTES.txt
+++ b/charts/metrics-aggregator/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "metrics-aggregator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "metrics-aggregator.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "metrics-aggregator.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "metrics-aggregator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/metrics-aggregator/templates/_helpers.tpl
+++ b/charts/metrics-aggregator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metrics-aggregator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metrics-aggregator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metrics-aggregator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "metrics-aggregator.labels" -}}
+helm.sh/chart: {{ include "metrics-aggregator.chart" . }}
+{{ include "metrics-aggregator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metrics-aggregator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metrics-aggregator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metrics-aggregator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "metrics-aggregator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/metrics-aggregator/templates/deployment.yaml
+++ b/charts/metrics-aggregator/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "metrics-aggregator.fullname" . }}
+  labels:
+    {{- include "metrics-aggregator.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "metrics-aggregator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "metrics-aggregator.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "metrics-aggregator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/metrics-aggregator/templates/hpa.yaml
+++ b/charts/metrics-aggregator/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "metrics-aggregator.fullname" . }}
+  labels:
+    {{- include "metrics-aggregator.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "metrics-aggregator.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/metrics-aggregator/templates/ingress.yaml
+++ b/charts/metrics-aggregator/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "metrics-aggregator.fullname" . }}
+  labels:
+    {{- include "metrics-aggregator.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "metrics-aggregator.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/metrics-aggregator/templates/service.yaml
+++ b/charts/metrics-aggregator/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "metrics-aggregator.fullname" . }}
+  labels:
+    {{- include "metrics-aggregator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "metrics-aggregator.selectorLabels" . | nindent 4 }}

--- a/charts/metrics-aggregator/templates/serviceaccount.yaml
+++ b/charts/metrics-aggregator/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "metrics-aggregator.serviceAccountName" . }}
+  labels:
+    {{- include "metrics-aggregator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/metrics-aggregator/templates/tests/test-connection.yaml
+++ b/charts/metrics-aggregator/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "metrics-aggregator.fullname" . }}-test-connection"
+  labels:
+    {{- include "metrics-aggregator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "metrics-aggregator.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/metrics-aggregator/values.yaml
+++ b/charts/metrics-aggregator/values.yaml
@@ -132,3 +132,14 @@ datadog:
   providers:
     gke:
       autopilot: true
+
+prometheus:
+  # https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
+  prometheus-node-exporter:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+  kube-state-metrics:
+    enabled: false
+  alertmanager:
+    enabled: false

--- a/charts/metrics-aggregator/values.yaml
+++ b/charts/metrics-aggregator/values.yaml
@@ -124,7 +124,11 @@ affinity: {}
 
 datadog:
   # https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml
-  apiKeyExistingSecret: datadog-secret
-  site: datadoghq.com
+  datadog:
+    apiKeyExistingSecret: datadog-secret
+    site: datadoghq.com
   clusterAgent:
     enabled: false
+  providers:
+    gke:
+      autopilot: true

--- a/charts/metrics-aggregator/values.yaml
+++ b/charts/metrics-aggregator/values.yaml
@@ -1,0 +1,130 @@
+# Default values for metrics-aggregator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+datadog:
+  # https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml
+  apiKeyExistingSecret: datadog-secret
+  site: datadoghq.com
+  clusterAgent:
+    enabled: false


### PR DESCRIPTION
Initial implementation of metrics-aggregator service using parent / sub chart Helm pattern. 

The chart defined in Chart.yaml contains 3 subchart references:
1. datadog agent
2. prometheus
3. river-metrics-discovery

Configuration values in metrics-aggregator/values.yaml are only provided for `datadog` with the intent of matching
configuration with currently deployed agent in AWS metrics-aggregator ECS service.

To test the metrics-aggregator chart:

```
helm dependency update helm-charts/charts/metrics-aggregator
# view rendered manifest that will be deployed to cluster
cd charts && helm install metrics-aggregator ./metrics-aggregator --dry-run
```

In a subsequent PR, I will add prometheus and river-metrics-discovery with identical configuration as is currently deployed based on terraform config. I will also use make use of subchart template references using `include` to reuse templates from the parent chart in the subchart for river-metrics-discovery which will be defined with custom manifest files in this repo. 

Update 01/15:

Had to make values changes for datadog, prometheus charts to deprecate unneeded images from the Deployment and allow for GKE Autopilot to work with datadog chart. As of now when running a `helm install metrics-aggregator .` on the cluster, datadog agent (as a daemonSet) and prometheus server are both created successfully running in the cluster. 

<img width="636" alt="Screenshot 2025-01-15 at 4 04 20 PM" src="https://github.com/user-attachments/assets/8478193c-31de-41a9-a72b-539f2437f9ec" />

Will add river-metrics-discovery service last as a custom subchart Deployment of the image in a ReplicaSet.

Note: We need to make sure we're okay with using the prometheus-community helm chart and associated prometheus image. It seems to be the best maintained one I could find.
