### PR TITLE
Cert manager app

### DIFF
--- a/charts/root-app/templates/cert-manager.yaml
+++ b/charts/root-app/templates/cert-manager.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cert-manager
-  namespace: argocd
 spec:
   destination:
     name: in-cluster
@@ -12,13 +11,13 @@ spec:
     repoURL: https://charts.jetstack.io
     targetRevision: v1.16.2
     chart: cert-manager
-  helm:
-    values: |
-      crds:
-        enabled: true
-      global:
-        leaderElection:
-          namespace: cert-manager
+    helm:
+      values: |
+        crds:
+          enabled: true
+        global:
+          leaderElection:
+            namespace: cert-manager
   syncPolicy:
     automated:
       prune: true

--- a/charts/root-app/templates/cert-manager.yaml
+++ b/charts/root-app/templates/cert-manager.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+spec:
+  destination:
+    name: in-cluster
+    namespace: cert-manager
+  project: default
+  source:
+    repoURL: https://charts.jetstack.io
+    targetRevision: v1.16.2
+    chart: cert-manager
+  helm:
+    values: |
+      crds:
+        enabled: true
+      global:
+        leaderElection:
+          namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
cert-manager app manifest to issue / manage tls certs within a given cluster. This repo follows app-of-apps pattern and as such the app manifest that the root-app watches over simply needs to exist under `charts/root-app/templates` as an Application compliant CRD manifest (this pr). 

To setup cert-manager and get a working tls cert from LetsEncrypt for hostname test-alb.towns.com, I followed cert-manager [tutorial](https://cert-manager.io/v1.1-docs/tutorials/acme/ingress/#step-2---deploy-the-nginx-ingress-controller) which uses nginx for Ingress (along with whatever GCP provisions on the ALB side). There were modifications needed to get this working that can be seen in custom `values` passed into the chart. 

To deploy App either merge this pr, or run:

```
kubectl apply -f charts/root-app/templates/cert-manager.yaml
```


![Screenshot 2025-01-29 at 3 43 50 PM](https://github.com/user-attachments/assets/30abfecb-9822-429d-b5e9-9d1441b96379)
